### PR TITLE
Added discovery_info check to LCN light platform

### DIFF
--- a/homeassistant/components/light/lcn.py
+++ b/homeassistant/components/light/lcn.py
@@ -19,6 +19,9 @@ DEPENDENCIES = ['lcn']
 async def async_setup_platform(hass, hass_config, async_add_entities,
                                discovery_info=None):
     """Set up the LCN light platform."""
+    if discovery_info is None:
+        return
+    
     import pypck
 
     devices = []


### PR DESCRIPTION
## Description:
Added a guard clause to the LCN light plarform to catch the case where discovery_info is None.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
